### PR TITLE
don't request updates when the document isn't focused

### DIFF
--- a/index.html
+++ b/index.html
@@ -11514,7 +11514,7 @@ var Updater = Class({
         this.update_timer = setInterval(function(){
             // Do not poll the machine when uploading
             // If there is no ip, we don't know where to find the machine so don't poll the machine
-            if(!fabrica.machine.uploading && fabrica.machine.ip){
+            if(!fabrica.machine.uploading && fabrica.machine.ip && document.hasFocus()){
                 fabrica.machine.send_command("M105\nM119\nM114\nprogress\n", _that.update_received);
             }
         }, 1000);

--- a/src/core/updater.js
+++ b/src/core/updater.js
@@ -11,7 +11,7 @@ var Updater = Class({
         this.update_timer = setInterval(function(){
             // Do not poll the machine when uploading
             // If there is no ip, we don't know where to find the machine so don't poll the machine
-            if(!fabrica.machine.uploading && fabrica.machine.ip){
+            if(!fabrica.machine.uploading && fabrica.machine.ip && document.hasFocus()){
                 fabrica.machine.send_command("M105\nM119\nM114\nprogress\n", _that.update_received);
             }
         }, 1000);


### PR DESCRIPTION
smoothie would be unresponsive when I had fabrica tabs open on other computers that I had forgotten about. however, there are times when you want fabrica to still request updates when the window isn't in focus, so once settings are implemented this can be configurable.
